### PR TITLE
Wrap .Destination in quotes

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,7 +1,7 @@
 {{ $link := .Destination }}
 {{ $isRemote := strings.HasPrefix $link "http" }}
 {{- if not $isRemote -}}
-{{ $url := urls.Parse .Destination }}
+{{ $url := urls.Parse ".Destination" }}
 {{- if $url.Path -}}
 {{ $fragment := "" }}
 {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}


### PR DESCRIPTION
Thank you for your wonderful repo. The file render-link.html works for me in Hugo 0.87, however, with a link like `[external url](https://github.com)`, I get a Go error `
execute of template failed: template: _default/_markup/render-link.html:4:15: executing "_default/_markup/render-link.html" at <urls.Parse>: error calling Parse: parse "": first path segment in URL cannot contain colon` (I stripped actual URL from this message). Wrapping `.Destination` in double quotes fixes it. 

(+1 to making this the default Hugo behavior.)
